### PR TITLE
Use compression none for clickhouse_driver

### DIFF
--- a/ch-bench-rust-driver/src/main.rs
+++ b/ch-bench-rust-driver/src/main.rs
@@ -1,10 +1,11 @@
 use clickhouse_driver::prelude::*;
-use std::error::Error;
+use std::{error::Error, time::Instant};
 
 async fn execute(database_url: String) -> Result<(), Box<dyn Error>> {
     let pool = Pool::create(database_url.as_str())?;
     let mut conn = pool.connection().await?;
     let mut total: u64 = 0;
+    let start = Instant::now();
 
     let mut result = conn
         .query("SELECT number FROM system.numbers_mt LIMIT 500000000")
@@ -13,14 +14,14 @@ async fn execute(database_url: String) -> Result<(), Box<dyn Error>> {
     while let Some(block) = result.next().await? {
         total += block.row_count();
     }
-    println!("Rows: {}", total);
-
+    let elapsed = start.elapsed();
+    println!("Rows: {}, elspsed: {} ms", total, elapsed.as_millis());
     Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    execute("tcp://localhost:9000".to_string()).await?;
+    execute("tcp://localhost:9000?compression=none".to_string()).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Mac M1Max
```
Rows: 500000000, elspsed: 727 ms
```

AMD Ryzen 9 5950X 16-Core Processor
```
❯ ./target/release/ch-bench-rust-driver
Rows: 500000000, elspsed: 1353 ms
```