### PR TITLE
Update Java benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries for programs and plugins
 *.class
 *.jar
+*.jfr
 *.exe
 *.exe~
 *.dll
@@ -17,5 +18,6 @@
 # vendor/
 
 .idea
+.vscode
 
 bin/ch-*

--- a/README.md
+++ b/README.md
@@ -20,19 +20,20 @@ Processed 500.07 million rows,
 Note: due to row-oriented design of most libraries, overhead per single row
 is significantly higher, so results can be slightly surprising.
 
-| Name                                       | Time  | RAM  | Ratio |
-|--------------------------------------------|-------|------|-------|
-| **[go-faster/ch][faster]** (Go)            | 401ms | 9M   | ~1x   |
-| [clickhouse-client][client] (C++)          | 387ms | 91M  | ~1x   |
-| [vahid-sohrabloo/chconn][vahid] (Go)       | 472ms | 9M   | ~1x   |
-| [clickhouse-cpp][cpp] (C++)                | 516ms | 6.9M | 1.47x |
-| [clickhouse_driver][rs] (Rust)             | 614ms | 9M   | 1.72x |
-| [uptrace][uptrace] (Go)                    | 1.2s  | 8M   | 3x    |
-| [clickhouse-go][go] (Go)                   | 6.5s  | 21M  | 16x   |
-| [clickhouse-jdbc][jdbc] (Java, HTTP)       | 10s   | 702M | 28x   |
-| [loyd/clickhouse.rs][rs-http] (Rust, HTTP) | 10s   | 7.2M | 28x   |
-| [clickhouse-driver][py] (Python)           | 37s   | 60M  | 106x  |
-| [mailru/go-clickhouse][mail] (Go, HTTP)    | 4m13s | 13M  | 729x  |
+| Name                                          | Time  | RAM  | Ratio |
+|-----------------------------------------------|-------|------|-------|
+| **[go-faster/ch][faster]** (Go)               | 401ms | 9M   | ~1x   |
+| [clickhouse-client][client] (C++)             | 387ms | 91M  | ~1x   |
+| [vahid-sohrabloo/chconn][vahid] (Go)          | 472ms | 9M   | ~1x   |
+| [clickhouse-cpp][cpp] (C++)                   | 516ms | 6.9M | 1.47x |
+| [clickhouse_driver][rs] (Rust)                | 614ms | 9M   | 1.72x |
+| [uptrace][uptrace] (Go)                       | 1.2s  | 8M   | 3x    |
+| [clickhouse-go][go] (Go)                      | 6.5s  | 21M  | 16x   |
+| [clickhouse-client][java-client] (Java, HTTP) | 10s   | 702M | 28x   |
+| [clickhouse-jdbc][jdbc] (Java, HTTP)          | 10s   | 702M | 28x   |
+| [loyd/clickhouse.rs][rs-http] (Rust, HTTP)    | 10s   | 7.2M | 28x   |
+| [clickhouse-driver][py] (Python)              | 37s   | 60M  | 106x  |
+| [mailru/go-clickhouse][mail] (Go, HTTP)       | 4m13s | 13M  | 729x  |
 
 [client]:  https://clickhouse.com/docs/en/interfaces/cli/ "Native command-line client (Official)"
 [faster]:  https://github.com/go-faster/ch "go-faster/ch"
@@ -40,7 +41,8 @@ is significantly higher, so results can be slightly surprising.
 [rs-http]: https://github.com/loyd/clickhouse.rs "A typed client for ClickHouse (HTTP)"
 [cpp]:     https://github.com/ClickHouse/clickhouse-cpp "C++ client library for ClickHouse (Official)"
 [vahid]:   https://github.com/vahid-sohrabloo/chconn "Low-level ClickHouse database driver for Golang"
-[jdbc]:    https://github.com/ClickHouse/clickhouse-jdbc "DBC driver for ClickHouse (Official)"
+[java-client]:    https://github.com/ClickHouse/clickhouse-jdbc/tree/develop/clickhouse-client "Java client for ClickHouse (Official)"
+[jdbc]:    https://github.com/ClickHouse/clickhouse-jdbc/tree/develop/clickhouse-jdbc "JDBC driver for ClickHouse (Official)"
 [py]:      https://github.com/mymarilyn/clickhouse-driver
 [go]:      https://github.com/ClickHouse/clickhouse-go "Golang driver for ClickHouse (Official)"
 [mail]:    https://github.com/mailru/go-clickhouse "Golang SQL database driver (HTTP, TSV format)"

--- a/ch-bench-java/run.sh
+++ b/ch-bench-java/run.sh
@@ -2,26 +2,28 @@
 
 set -e
 
-: ${DB_HOST:="localhost"}
-: ${DB_PORT:="8123"}
-: ${DRIVER_VERSION:="0.3.2-test3"}
-: ${COMPRESS:="false"}
+: ${SQL:="SELECT number FROM system.numbers_mt LIMIT 500000000"}
+: ${URL:='http://localhost?!compress&format=RowBinaryWithNamesAndTypes'}
+: ${VER:="0.3.2-patch10"}
 
-JDBC_DRIVER="clickhouse-jdbc-$DRIVER_VERSION-http.jar"
+: ${OPTS:=""}
+#OPTS="-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+FlightRecorder -XX:StartFlightRecording=disk=false,filename=recorded.jfr,settings=profile"
+PKG="clickhouse-jdbc-$VER-all.jar"
 
-if [ ! -f "$JDBC_DRIVER" ]; then
-    echo "Downloading $JDBC_DRIVER..."
-    curl -sOL "https://github.com/ClickHouse/clickhouse-jdbc/releases/download/v$DRIVER_VERSION/$JDBC_DRIVER"
+
+if [ ! -f "$PKG" ]; then
+    echo "Downloading $PKG..."
+    curl -sOL "https://github.com/ClickHouse/clickhouse-jdbc/releases/download/v$VER/$PKG"
 else
-    echo "Found $JDBC_DRIVER"
+    echo "Found $PKG"
 fi
 
 if [ ! -f "Main.class" ]; then
     echo "Compiling..."
-    javac -cp "$JDBC_DRIVER" Main.java
+    javac -cp "$PKG" Main.java
 else
     echo "Found compiled class"
 fi
 
 echo "Running..."
-/usr/bin/time -v java -DdbHost="$DB_HOST" -DdbPort="$DB_PORT" -Dcompress="${COMPRESS}" -cp ".:$JDBC_DRIVER" Main $@
+\time -v java $OPTS -Durl="$URL" -Dsql="$SQL" -cp ".:$PKG" Main $@


### PR DESCRIPTION
Changes:
* bump Java driver to 0.3.2-patch10
* separate benchmarks for Java client and JDBC driver

To benchmark:
- Java client: `OPTS="-Xms24m -Xmx24m" ./run.sh long` (limit JVM heap size to 24MB)
- JDBC driver: `OPTS="-Xms24m -Xmx24m" ./run.sh`

To change target server(s) and/or use different query:
- Java client: `SQL="select number, toString(number) str from numbers(500000000)" URL='http://server1,(tcp://server2),(grpc://server3)/system?!compress&format=RowBinaryWithNamesAndTypes&load_balancing_policy=random&health_check_interval=5000&failover=2'  ./run.sh record`
- JDBC driver: `SQL="select number, toString(number) str from numbers(500000000)" URL='http://user:password@server1?!compress&format=RowBinaryWithNamesAndTypes'  ./run.sh`