### PR TITLE
Add benchmark using curl and correct Java test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ is significantly higher, so results can be slightly surprising.
 | [clickhouse_driver][rs] (Rust)             | 614ms | 9M   | 1.72x |
 | [uptrace][uptrace] (Go)                    | 1.2s  | 8M   | 3x    |
 | [clickhouse-go][go] (Go)                   | 5.4s  | 21M  | 13.5x |
-| [clickhouse-jdbc][jdbc] (Java, HTTP)       | 6.4s  | 121M | 16x   |
-| [clickhouse-client][java] (Java, HTTP)     | 7.2s  | 120M | 18x   |
+| [curl][curl] (C, HTTP)                     | 5.4s  | 21M  | 13.5x |
+| [clickhouse-client][java] (Java, HTTP)     | 6.4s  | 121M | 16x   |
+| [clickhouse-jdbc][jdbc] (Java, HTTP)       | 7.2s  | 120M | 18x   |
 | [loyd/clickhouse.rs][rs-http] (Rust, HTTP) | 10s   | 7.2M | 28x   |
 | [clickhouse-driver][py] (Python)           | 37s   | 60M  | 106x  |
 | [mailru/go-clickhouse][mail] (Go, HTTP)    | 4m13s | 13M  | 729x  |
@@ -40,6 +41,7 @@ is significantly higher, so results can be slightly surprising.
 [rs]:      https://github.com/datafuse-extras/clickhouse_driver "datafuse-extras/clickhouse_driver"
 [rs-http]: https://github.com/loyd/clickhouse.rs "A typed client for ClickHouse (HTTP)"
 [cpp]:     https://github.com/ClickHouse/clickhouse-cpp "C++ client library for ClickHouse (Official)"
+[curl]:    https://github.com/curl/curl "A command-line tool for transferring data specified with URL syntax"
 [vahid]:   https://github.com/vahid-sohrabloo/chconn "Low-level ClickHouse database driver for Golang"
 [java]:    https://github.com/ClickHouse/clickhouse-jdbc/tree/develop/clickhouse-client "Java client for ClickHouse (Official)"
 [jdbc]:    https://github.com/ClickHouse/clickhouse-jdbc/tree/develop/clickhouse-jdbc "JDBC driver for ClickHouse (Official)"

--- a/ch-bench-java/run.sh
+++ b/ch-bench-java/run.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+#
+# Java client:
+#   - ./run.sh long
+#   - ./run.sh record
+#   - ./run.sh skip
+#   - OPTS="-Xms24m -Xmx24m" ./run.sh long
+#
+# JDBC driver: ./run.sh
+#
+
 set -e
 
 : ${SQL:="SELECT number FROM system.numbers_mt LIMIT 500000000"}
@@ -18,7 +28,8 @@ else
     echo "Found $PKG"
 fi
 
-if [ ! -f "Main.class" ]; then
+if [ ! -f "Main.class" ] || [ "Main.java" -nt "Main.class" ]; then
+    rm -fv Main.class
     echo "Compiling..."
     javac -cp "$PKG" Main.java
 else

--- a/curl/run.sh
+++ b/curl/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+: ${FMT:="RowBinaryWithNamesAndTypes"}
+: ${SQL:="SELECT number FROM system.numbers_mt LIMIT 500000000"}
+: ${URL:="http://localhost:8123"}
+
+\time -v curl -s -H "X-ClickHouse-Format: $FMT" --get --data-urlencode "query=$SQL" "$URL" > /dev/null


### PR DESCRIPTION
* Add benchmark using curl - there's no deserialization but it's useful to understand "limit" of http interface
* Correct Java test results - JDBC driver is built on top of Java client, so it's always slower
* Add skip option in Java benchmark to skip all bytes(without converting to corresponding data types)